### PR TITLE
Refine smart vibe surfaces and tagging

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4,29 +4,43 @@
     --off: #F8F6F2;
     --gold: #FFC857;
     --ink: #0F172A;
+    --cluster-techno: linear-gradient(135deg, #201547, #6C5CE7);
+    --cluster-jazz: linear-gradient(135deg, #402e08, #FF9F1C);
+    --cluster-performance: linear-gradient(135deg, #05342f, #2EC4B6);
+    --cluster-talks: linear-gradient(135deg, #4b0d1d, #FF4F87);
+    --cluster-experimental: linear-gradient(135deg, #0b1a3c, #4B7BEC);
+    --pulse-color: rgba(255, 79, 79, .08);
+    --pulse-color-dark: rgba(64, 140, 255, .18);
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
 }
 
 * {
-    box-sizing: border-box
+    box-sizing: border-box;
 }
 
 html,
 body {
     margin: 0;
-    background: var(--off);
+    min-height: 100%;
+    background:
+        radial-gradient(circle at 15% 10%, var(--pulse-color, rgba(255, 79, 79, .08)), transparent 55%),
+        var(--off);
     color: var(--ink);
-    font: 16px/1.5 Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif
+    font: 16px/1.5 "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
 }
 
 .container {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 1.25rem
+    padding: 1.25rem;
+    padding-left: max(1.25rem, env(safe-area-inset-left));
+    padding-right: max(1.25rem, env(safe-area-inset-right));
 }
 
 .hero {
     padding-top: 2rem;
-    padding-bottom: .75rem
+    padding-bottom: .75rem;
 }
 
 .brand .logo {
@@ -34,46 +48,172 @@ body {
     color: var(--coral);
     font-weight: 800;
     letter-spacing: .02em;
-    font-size: clamp(2.2rem, 6vw, 4rem)
+    font-size: clamp(2.2rem, 6vw, 4rem);
 }
 
 .brand .tagline {
     margin: .25rem 0 0;
     color: var(--navy);
-    font-size: clamp(1rem, 2.3vw, 1.5rem)
+    font-size: clamp(1rem, 2.3vw, 1.5rem);
 }
 
 .filters {
+    position: sticky;
+    top: calc(env(safe-area-inset-top) + 8px);
+    z-index: 10;
     display: flex;
     flex-wrap: wrap;
     gap: .5rem;
-    margin-top: 1rem
+    margin-top: 1rem;
+    align-items: center;
+    padding: .5rem;
+    background: rgba(255, 255, 255, .75);
+    border-radius: 16px;
+    box-shadow: 0 12px 32px rgba(13, 27, 42, .08);
+    backdrop-filter: blur(10px);
 }
 
-.filters button {
+.chip {
     border: 1px solid #e6e6e6;
     background: #fff;
     border-radius: 999px;
-    padding: .5rem .9rem;
-    cursor: pointer
+    padding: .6rem 1rem;
+    cursor: pointer;
+    min-height: 44px;
+    transition: transform .15s ease, box-shadow .15s ease;
+}
+
+.chip:active,
+.card a:active {
+    transform: translateY(1px);
 }
 
 .chip--active {
     border-color: var(--navy);
     color: #fff;
-    background: var(--navy)
+    background: var(--navy);
 }
 
 .chip--accent {
     background: var(--gold);
-    border-color: transparent
+    border-color: transparent;
+}
+
+.cluster-deck {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    margin-top: .5rem;
+    margin-bottom: 1.5rem;
+}
+
+.cluster-card {
+    position: relative;
+    padding: 1.1rem 1.2rem;
+    border-radius: 20px;
+    overflow: hidden;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    gap: .45rem;
+    background: var(--cluster-sheen, #1f2937);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, .28);
+}
+
+.cluster-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(160deg, rgba(255, 255, 255, .25), transparent 45%);
+    opacity: .5;
+    pointer-events: none;
+}
+
+.cluster-card__title {
+    font-weight: 700;
+    letter-spacing: .03em;
+    text-transform: uppercase;
+    font-size: .8rem;
+    opacity: .85;
+}
+
+.cluster-card__count {
+    font-size: 1.6rem;
+    font-weight: 700;
+}
+
+.cluster-card__sample {
+    font-size: .9rem;
+    opacity: .9;
+}
+
+.cluster-card[data-vibe="techno"] { --cluster-sheen: var(--cluster-techno); }
+.cluster-card[data-vibe="jazz"] { --cluster-sheen: var(--cluster-jazz); }
+.cluster-card[data-vibe="performance"] { --cluster-sheen: var(--cluster-performance); }
+.cluster-card[data-vibe="talks"] { --cluster-sheen: var(--cluster-talks); }
+.cluster-card[data-vibe="experimental"] { --cluster-sheen: var(--cluster-experimental); }
+
+.density {
+    margin-bottom: 1.5rem;
+}
+
+.density__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: .75rem;
+}
+
+.density__cell {
+    background: rgba(13, 27, 42, .07);
+    border-radius: 18px;
+    padding: .75rem 1rem;
+    display: grid;
+    gap: .35rem;
+    align-items: flex-start;
+    position: relative;
+    overflow: hidden;
+}
+
+.density__cell::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: var(--density-color, rgba(255, 79, 79, .15));
+    opacity: var(--density-strength, .1);
+    transition: opacity .2s ease;
+    pointer-events: none;
+}
+
+.density__day {
+    font-weight: 600;
+    letter-spacing: .02em;
+    font-size: .95rem;
+}
+
+.density__count {
+    font-size: 1.25rem;
+    font-weight: 700;
+}
+
+.density__bar {
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, .1);
+    overflow: hidden;
+}
+
+.density__bar span {
+    display: block;
+    height: 100%;
+    background: var(--density-color, #FF4F4F);
+    width: calc(var(--density-strength, .1) * 100%);
 }
 
 .grid {
     display: grid;
     gap: 1rem;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    margin-top: 1rem
+    margin-top: 1rem;
 }
 
 .spotlight {
@@ -86,12 +226,12 @@ body {
     box-shadow: 0 12px 32px rgba(255, 200, 87, .25);
     opacity: 0;
     transform: translateY(.25rem);
-    transition: opacity .25s ease, transform .25s ease
+    transition: opacity .25s ease, transform .25s ease;
 }
 
 .spotlight--visible {
     opacity: 1;
-    transform: translateY(0)
+    transform: translateY(0);
 }
 
 .spotlight strong {
@@ -99,19 +239,19 @@ body {
     font-size: .75rem;
     letter-spacing: .08em;
     text-transform: uppercase;
-    margin-bottom: .25rem
+    margin-bottom: .25rem;
 }
 
 .spotlight__title {
     font-size: 1.1rem;
     font-weight: 600;
-    margin-bottom: .2rem
+    margin-bottom: .2rem;
 }
 
 .spotlight__meta {
     font-size: .9rem;
     opacity: .8;
-    margin-bottom: .6rem
+    margin-bottom: .6rem;
 }
 
 .spotlight__link {
@@ -120,13 +260,13 @@ body {
     gap: .35rem;
     font-weight: 600;
     color: inherit;
-    text-decoration: none
+    text-decoration: none;
 }
 
 .spotlight__link::after {
     content: '→';
     font-size: 1rem;
-    line-height: 1
+    line-height: 1;
 }
 
 .card {
@@ -137,12 +277,12 @@ body {
     display: flex;
     flex-direction: column;
     gap: .35rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, .04)
+    box-shadow: 0 1px 3px rgba(0, 0, 0, .04);
 }
 
 .card--highlight {
     box-shadow: 0 0 0 3px rgba(255, 79, 79, .35), 0 16px 32px rgba(255, 79, 79, .2);
-    animation: cardPulse 1.4s ease
+    animation: cardPulse 1.4s ease;
 }
 
 .badge {
@@ -151,49 +291,47 @@ body {
     padding: .25rem .6rem;
     border-radius: 999px;
     background: #f3f4f6;
-    border: 1px solid #e5e7eb
+    border: 1px solid #e5e7eb;
 }
 
-.badge--date {
-    background: #FFEBD1;
-    border-color: #FFD69B
-}
-
-.badge--girls {
-    background: #FDE1EA;
-    border-color: #F7B7CE
-}
-
-.badge--quiz {
-    background: #E6F0FF;
-    border-color: #C8DCFF
-}
-
-.badge--cinema {
-    background: #EAF7F3;
-    border-color: #CFEFE4
-}
-
-.badge--rave {
-    background: #FFE3E3;
-    border-color: #FFC9C9
-}
+.badge--date { background: #FFEBD1; border-color: #FFD69B; }
+.badge--girls { background: #FDE1EA; border-color: #F7B7CE; }
+.badge--quiz { background: #E6F0FF; border-color: #C8DCFF; }
+.badge--cinema { background: #EAF7F3; border-color: #CFEFE4; }
+.badge--rave { background: #FFE3E3; border-color: #FFC9C9; }
+.badge--live { background: #FFE7F6; border-color: #F9B4E4; }
+.badge--dj { background: #E7EEFF; border-color: #CBD7FF; }
+.badge--jazz { background: #EFE8FF; border-color: #D5C7FF; }
+.badge--bar { background: #FFF1E0; border-color: #FFD9A8; }
+.badge--culture { background: #EAF7F3; border-color: #CFEFE4; }
+.badge--opening { background: #FFF3D1; border-color: #FFE29B; }
+.badge--lecture { background: #E8F4FF; border-color: #C8E4FF; }
+.badge--festival { background: #FDE5D9; border-color: #FBC2A0; }
+.badge--source { background: #E6F3FF; border-color: #C0E1FF; }
 
 .card h3 {
     margin: .2rem 0 .1rem;
-    font-size: 1.15rem
+    font-size: 1.15rem;
 }
 
 .card p {
     margin: 0;
-    color: #475569
+    color: #475569;
 }
 
 .meta {
     display: flex;
     gap: .5rem;
     flex-wrap: wrap;
-    margin-top: .25rem
+    margin-top: .25rem;
+}
+
+.card__sources {
+    font-size: .8rem;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    margin-top: .35rem;
+    opacity: .75;
 }
 
 .card a {
@@ -203,148 +341,64 @@ body {
     border-radius: 12px;
     background: var(--navy);
     color: #fff;
-    text-align: center
+    text-align: center;
+    transition: transform .15s ease;
 }
 
 .footer {
     opacity: .7;
-    font-size: .9rem
+    font-size: .9rem;
+    padding-bottom: calc(env(safe-area-inset-bottom) + 24px);
 }
 
 @keyframes cardPulse {
-    0% {
-        transform: scale(1)
-    }
-
-    50% {
-        transform: scale(1.015)
-    }
-
-    100% {
-        transform: scale(1)
-    }
+    0% { transform: scale(1); }
+    50% { transform: scale(1.015); }
+    100% { transform: scale(1); }
 }
 
-@media (prefers-color-scheme:dark) {
+@media (max-width: 420px) {
+    html { font-size: 17px; }
+}
+
+@media (prefers-color-scheme: dark) {
     body {
-        background: #0b1220;
-        color: #e5e7eb
+        background:
+            radial-gradient(circle at 15% 10%, var(--pulse-color-dark, rgba(64, 140, 255, .18)), transparent 55%),
+            #0b1220;
+        color: #e5e7eb;
+    }
+
+    .brand .tagline { color: #cbd5e1; }
+
+    .filters {
+        background: rgba(15, 23, 42, .72);
+        box-shadow: 0 12px 32px rgba(8, 15, 26, .4);
+    }
+
+    .chip {
+        background: #0f172a;
+        border-color: #1f2937;
+        color: #e5e7eb;
     }
 
     .card {
         background: #0f172a;
-        border-color: #0b1220
+        border-color: #0b1220;
     }
 
-    .filters button {
-        background: #0f172a;
-        border-color: #1f2937;
-        color: #e5e7eb
+    .card a {
+        background: #1f2a3a;
+        color: #f8fafc;
+    }
+
+    .badge {
+        color: #0f172a;
     }
 
     .spotlight {
         background: #1e293b;
         color: #f8fafc;
-        box-shadow: 0 18px 36px rgba(8, 15, 26, .45)
+        box-shadow: 0 18px 36px rgba(8, 15, 26, .45);
     }
-}
-
-@media (prefers-color-scheme:dark) {
-    .brand .tagline {
-        color: #cbd5e1;
-    }
-
-    /* lysere tekst */
-    .card a {
-        background: #1f2a3a;
-    }
-
-    /* lysere CTA på mørk bakgrunn */
-    .badge {
-        color: #0f172a;
-    }
-
-    /* mørk tekst på lyse badges */
-}
-
-.filters button {
-    min-height: 44px;
-    padding: .6rem 1rem;
-}
-
-.filters button:active,
-.card a:active {
-    transform: translateY(1px);
-}
-
-:root {
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
-}
-
-@media (max-width:420px) {
-    html {
-        font-size: 17px;
-    }
-}
-
-/* Legg til i styles.css */
-html,
-body {
-    min-height: 100%;
-    background: var(--off);
-}
-
-@media (prefers-color-scheme: dark) {
-
-    html,
-    body {
-        background: #0b1220;
-    }
-
-    /* samme som resten */
-    .brand .tagline {
-        color: #cbd5e1;
-    }
-
-    /* mer kontrast på tagline */
-    .card a {
-        background: #1f2a3a;
-    }
-
-    /* bedre CTA på mørk bakgrunn */
-    .badge {
-        color: #0f172a;
-    }
-
-    /* mørk tekst på lyse badges */
-}
-
-.footer {
-    padding-bottom: calc(env(safe-area-inset-bottom) + 24px);
-}
-
-.container {
-    padding-left: max(1.25rem, env(safe-area-inset-left));
-    padding-right: max(1.25rem, env(safe-area-inset-right));
-}
-
-.filters button {
-    min-height: 44px;
-    padding: .6rem 1rem;
-}
-
-.filters button:active,
-.card a:active {
-    transform: translateY(1px);
-}
-
-.filters {
-    position: sticky;
-    top: calc(env(safe-area-inset-top) + 8px);
-    z-index: 10;
-    backdrop-filter: blur(6px);
-    background: rgba(13, 27, 42, .35);
-    border-radius: 16px;
-    padding: .5rem;
 }

--- a/index.html
+++ b/index.html
@@ -27,18 +27,12 @@
             <h1 class="logo">SPONTIS</h1>
             <p class="tagline">What’s on. Right now.</p>
         </div>
-        <nav class="filters">
-            <button data-filter="all" class="chip chip--active">All</button>
-            <button data-filter="date">Date night ❤️</button>
-            <button data-filter="girls">Girls' night 🍷</button>
-            <button data-filter="quiz">Quiz 🍻</button>
-            <button data-filter="cinema">Cinema 🎥</button>
-            <button data-filter="rave">Rave 🔊</button>
-            <button id="surprise" class="chip chip--accent">Inspire me</button>
-        </nav>
+        <nav class="filters" id="filters" aria-label="Filter events"></nav>
     </header>
 
     <main class="container">
+        <section id="cluster-deck" class="cluster-deck" aria-label="Event vibes"></section>
+        <section id="density-map" class="density" aria-label="Weekly pulse"></section>
         <div id="spotlight" class="spotlight" role="status" aria-live="polite" hidden></div>
         <section id="events" class="grid"></section>
     </main>

--- a/js/app.js
+++ b/js/app.js
@@ -1,36 +1,325 @@
-const $ = s => document.querySelector(s);
+const $ = selector => document.querySelector(selector);
+
 const eventsEl = $('#events');
-const filterBar = document.querySelector('.filters');
+const filterBar = $('#filters');
 const spotlightEl = $('#spotlight');
+const clusterDeckEl = $('#cluster-deck');
+const densityEl = $('#density-map');
 
 const TAG_STYLE = {
-    date: 'badge--date', girls: 'badge--girls', quiz: 'badge--quiz',
-    cinema: 'badge--cinema', rave: 'badge--rave'
+    date: 'badge--date',
+    girls: 'badge--girls',
+    quiz: 'badge--quiz',
+    cinema: 'badge--cinema',
+    rave: 'badge--rave',
+    live: 'badge--live',
+    dj: 'badge--dj',
+    jazz: 'badge--jazz',
+    bar: 'badge--bar',
+    culture: 'badge--culture',
+    opening: 'badge--opening',
+    lecture: 'badge--lecture',
+    festival: 'badge--festival',
+    source: 'badge--source'
 };
 
+const TAG_LABELS = {
+    all: 'All',
+    bar: 'Bar night 🍸',
+    culture: 'Culture 🎭',
+    date: 'Date night ❤️',
+    dj: 'DJ set 🎧',
+    festival: 'Festival 🌟',
+    girls: "Girls' night 🍷",
+    jazz: 'Jazz 🎷',
+    lecture: 'Talks 🎤',
+    live: 'Live 🎸',
+    opening: 'Opening ✨',
+    quiz: 'Quiz 🍻',
+    cinema: 'Cinema 🎥',
+    rave: 'Rave 🔊'
+};
+
+const SMART_TAG_RULES = [
+    { tag: 'live', pattern: /\bkonsert\b|\blive\b|concert|gig|setlist|band/iu },
+    { tag: 'dj', pattern: /\bdj\b|selector|club\s?night|techno|house|rave|club/iu },
+    { tag: 'jazz', pattern: /jazz|swing|impro(vis|v)|sax/iu },
+    { tag: 'girls', pattern: /girls'?\s?night|ladies'?|venninn/iu },
+    { tag: 'date', pattern: /date\s?night|romance|romantisk|couples?/iu },
+    { tag: 'cinema', pattern: /cinema|kino|screening|film/iu },
+    { tag: 'bar', pattern: /vinylbar|bar\b|cocktail|taproom|pub/iu },
+    { tag: 'culture', pattern: /kultur|museum|gallery|teater|theatre|performance/iu },
+    { tag: 'opening', pattern: /opening|vernissage|launch|grand opening|åpning/iu },
+    { tag: 'lecture', pattern: /lecture|talk|samtale|conversation|panel|debate|foredrag|seminar|artist talk|workshop/iu },
+    { tag: 'festival', pattern: /festival|weekender|marathon|takeover|all-?nighter/iu }
+];
+
+const BASE_FILTERS = ['all', 'date', 'girls', 'quiz', 'cinema', 'rave', 'live', 'dj', 'jazz', 'culture', 'bar'];
+
+const VIBE_PROFILES = [
+    {
+        id: 'techno',
+        label: 'Techno',
+        keywords: ['techno', 'club', 'rave', 'acid', 'house', 'electro', 'warehouse', 'dancefloor'],
+        tagHints: ['rave', 'dj'],
+        sourceHints: ['resident advisor', 'ra.', 'ostre', 'ekko']
+    },
+    {
+        id: 'jazz',
+        label: 'Jazz',
+        keywords: ['jazz', 'sax', 'saxophone', 'improv', 'soul', 'swing', 'blues', 'bebop'],
+        tagHints: ['jazz'],
+        sourceHints: ['nattjazz']
+    },
+    {
+        id: 'performance',
+        label: 'Performance',
+        keywords: ['konsert', 'concert', 'performance', 'show', 'theatre', 'theater', 'dance', 'ballet', 'cinema', 'screening'],
+        tagHints: ['cinema', 'date', 'girls', 'live', 'culture'],
+        sourceHints: ['kultur', 'teater', 'theatre', 'bergen kino']
+    },
+    {
+        id: 'talks',
+        label: 'Talks',
+        keywords: ['talk', 'lecture', 'conversation', 'debate', 'panel', 'quiz', 'workshop', 'seminar'],
+        tagHints: ['lecture', 'quiz'],
+        sourceHints: ['litteraturhuset', 'library']
+    },
+    {
+        id: 'experimental',
+        label: 'Experimental',
+        keywords: ['experimental', 'modular', 'ambient', 'noise', 'avant', 'installation', 'future', 'drone'],
+        tagHints: ['experimental'],
+        sourceHints: ['østre', 'ekko', 'bit teatergarasjen']
+    }
+];
+
+const VIBE_LOOKUP = Object.fromEntries(VIBE_PROFILES.map(profile => [profile.id, profile]));
+
+const WEEK = [
+    { index: 1, short: 'Mon', full: 'Monday' },
+    { index: 2, short: 'Tue', full: 'Tuesday' },
+    { index: 3, short: 'Wed', full: 'Wednesday' },
+    { index: 4, short: 'Thu', full: 'Thursday' },
+    { index: 5, short: 'Fri', full: 'Friday' },
+    { index: 6, short: 'Sat', full: 'Saturday' },
+    { index: 0, short: 'Sun', full: 'Sunday' }
+];
+
 let currentList = [];
+let currentFilter = 'all';
 let highlightTimer;
 
+function normalizeText(text = '') {
+    return text.toLowerCase().replace(/[^a-z0-9æøåäöüß ]+/gi, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function labelForTag(tag) {
+    return TAG_LABELS[tag] || tag.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function sortTags(tags) {
+    const order = BASE_FILTERS.filter(tag => tag !== 'all');
+    const weight = tag => {
+        const idx = order.indexOf(tag);
+        if (idx !== -1) return idx;
+        const first = typeof tag === 'string' && tag.length ? tag.charCodeAt(0) : 0;
+        return order.length + first / 100;
+    };
+    return [...tags].sort((a, b) => {
+        const diff = weight(a) - weight(b);
+        return diff === 0 ? a.localeCompare(b) : diff;
+    });
+}
+
+function getDayInfo(event) {
+    if (typeof event.dayIndex === 'number') {
+        const match = WEEK.find(day => day.index === event.dayIndex);
+        return match || null;
+    }
+
+    if (event.starts_at) {
+        const parsed = new Date(event.starts_at);
+        if (!Number.isNaN(parsed)) {
+            const match = WEEK.find(day => day.index === parsed.getDay());
+            if (match) return match;
+        }
+    }
+
+    if (event.when) {
+        const match = event.when.match(/^(mon|tue|wed|thu|fri|sat|sun)/i);
+        if (match) {
+            const dayKey = match[1].slice(0, 3).toLowerCase();
+            const info = WEEK.find(day => day.short.toLowerCase() === dayKey);
+            if (info) return info;
+        }
+    }
+
+    return null;
+}
+
+function dedupeEvents(events) {
+    const map = new Map();
+
+    for (const raw of events) {
+        const baseTitle = normalizeText(raw.title || '');
+        const day = getDayInfo(raw);
+        let dateKey = '';
+        if (raw.starts_at) {
+            const parsed = new Date(raw.starts_at);
+            if (!Number.isNaN(parsed.getTime())) {
+                dateKey = parsed.toISOString().slice(0, 10);
+            }
+        }
+        if (!dateKey) dateKey = day?.short || '';
+        const venueKey = normalizeText(raw.venue || raw.where || '');
+        const key = [baseTitle, dateKey, venueKey].filter(Boolean).join('|') || baseTitle;
+
+        const next = {
+            ...raw,
+            tags: Array.from(new Set(raw.tags || [])),
+            sources: raw.source ? [raw.source] : [],
+            sourceLinks: raw.source && raw.url ? [{ source: raw.source, url: raw.url }] : [],
+            dayIndex: day?.index ?? null
+        };
+
+        if (!map.has(key)) {
+            map.set(key, next);
+            continue;
+        }
+
+        const existing = map.get(key);
+        existing.tags = Array.from(new Set([...(existing.tags || []), ...(next.tags || [])]));
+
+        const mergedSources = new Set([...(existing.sources || []), ...(next.sources || [])].filter(Boolean));
+        existing.sources = Array.from(mergedSources);
+
+        if (!existing.sourceLinks) existing.sourceLinks = [];
+        for (const entry of next.sourceLinks || []) {
+            if (!existing.sourceLinks.some(item => item.url === entry.url)) {
+                existing.sourceLinks.push(entry);
+            }
+        }
+
+        if (!existing.url && next.url) existing.url = next.url;
+        if (!existing.when && next.when) existing.when = next.when;
+        if (!existing.where && next.where) existing.where = next.where;
+        if (!existing.description && next.description) existing.description = next.description;
+        if (!existing.summary && next.summary) existing.summary = next.summary;
+        if (existing.dayIndex == null && next.dayIndex != null) existing.dayIndex = next.dayIndex;
+    }
+
+    return Array.from(map.values());
+}
+
+function applySmartTags(event, combinedText) {
+    const tags = new Set(event.tags || []);
+    for (const rule of SMART_TAG_RULES) {
+        if (rule.pattern.test(combinedText)) {
+            tags.add(rule.tag);
+        }
+    }
+    event.tags = sortTags(tags);
+}
+
+function detectVibe(event, combinedText) {
+    const tags = event.tags || [];
+    let bestId = 'performance';
+    let bestScore = 0;
+
+    for (const profile of VIBE_PROFILES) {
+        let score = 0;
+        for (const keyword of profile.keywords) {
+            if (combinedText.includes(keyword)) {
+                score += keyword.length > 6 ? 2 : 1;
+            }
+        }
+
+        for (const hint of profile.tagHints || []) {
+            if (tags.includes(hint)) score += 2;
+        }
+
+        const sourceText = normalizeText(event.source || '');
+        for (const hint of profile.sourceHints || []) {
+            if (sourceText.includes(hint)) score += 1.5;
+        }
+
+        if (score > bestScore) {
+            bestId = profile.id;
+            bestScore = score;
+        }
+    }
+
+    if (!bestScore) {
+        const fallback = tags.includes('festival') ? 'experimental' : bestId;
+        return fallback;
+    }
+
+    return bestId;
+}
+
+function enrichEvents(events) {
+    const deduped = dedupeEvents(events);
+
+    return deduped.map(event => {
+        const combinedText = [
+            event.title,
+            event.description,
+            event.summary,
+            event.venue,
+            event.where,
+            (event.tags || []).join(' ')
+        ].filter(Boolean).join(' ').toLowerCase();
+
+        applySmartTags(event, combinedText);
+
+        event.vibe = detectVibe(event, combinedText);
+        event.vibeLabel = VIBE_LOOKUP[event.vibe]?.label || 'Performance';
+
+        const dayInfo = getDayInfo(event);
+        event.dayIndex = dayInfo?.index ?? null;
+        event.dayName = dayInfo?.full ?? null;
+        event.dayShort = dayInfo?.short ?? null;
+
+        if (!event.sources || !event.sources.length) {
+            event.sources = event.source ? [event.source] : [];
+        }
+
+        return event;
+    });
+}
+
 function paint(list) {
+    if (!eventsEl) return;
+
     if (!list.length) {
         eventsEl.innerHTML = `<p style="opacity:.7">No events yet. Try another filter or check back later.</p>`;
         return;
     }
-    eventsEl.innerHTML = list.map((e, idx) => {
-        const tags = (e.tags || []).map(t => `<span class="badge ${TAG_STYLE[t] || ''}">${t}</span>`).join('');
+
+    eventsEl.innerHTML = list.map((event, idx) => {
+        const tags = sortTags(event.tags || []);
+        const tagHtml = tags.map(tag => `<span class="badge ${TAG_STYLE[tag] || ''}">${labelForTag(tag)}</span>`).join('');
+        const sourceLine = event.sources && event.sources.length > 1
+            ? `<div class="card__sources">Kilder: ${event.sources.join(' + ')}</div>`
+            : '';
+        const whenWhere = [event.when, event.where].filter(Boolean).join(' • ');
+
         return `<article class="card" data-index="${idx}">
-      <span class="meta">${tags}</span>
-      <h3>${e.title}</h3>
-      <p>${e.when} • ${e.where}</p>
-      <a href="${e.url}" target="_blank" rel="noopener">Open</a>
+      <span class="meta">${tagHtml}</span>
+      <h3>${event.title}</h3>
+      <p>${whenWhere}</p>
+      ${sourceLine}
+      <a href="${event.url}" target="_blank" rel="noopener">Open</a>
     </article>`;
     }).join('');
 }
 
 function setActive(tag) {
-    document.querySelectorAll('.filters .chip').forEach(b =>
-        b.classList.toggle('chip--active', b.dataset.filter === tag)
-    );
+    if (!filterBar) return;
+    filterBar.querySelectorAll('.chip').forEach(button => {
+        button.classList.toggle('chip--active', button.dataset.filter === tag);
+    });
 }
 
 function clearSpotlight() {
@@ -42,15 +331,21 @@ function clearSpotlight() {
         clearTimeout(highlightTimer);
         highlightTimer = null;
     }
-    eventsEl.querySelectorAll('.card--highlight').forEach(el => el.classList.remove('card--highlight'));
+    eventsEl?.querySelectorAll('.card--highlight').forEach(el => el.classList.remove('card--highlight'));
 }
 
 function applyFilter(tag) {
     const all = window.__ALL || [];
-    const data = tag === 'all' ? all : all.filter(e => (e.tags || []).includes(tag));
+    const filtered = tag === 'all' ? all : all.filter(event => (event.tags || []).includes(tag));
+    const data = filtered.slice().sort((a, b) => {
+        const aTime = a.starts_at ? new Date(a.starts_at).getTime() : Infinity;
+        const bTime = b.starts_at ? new Date(b.starts_at).getTime() : Infinity;
+        return aTime - bTime;
+    });
     paint(data);
     setActive(tag);
     currentList = data;
+    currentFilter = tag;
     clearSpotlight();
 }
 
@@ -69,6 +364,7 @@ function showSpotlight(event) {
 }
 
 function highlightCard(index) {
+    if (!eventsEl) return;
     const card = eventsEl.querySelector(`.card[data-index="${index}"]`);
     if (!card) return;
     eventsEl.querySelectorAll('.card--highlight').forEach(el => el.classList.remove('card--highlight'));
@@ -79,6 +375,122 @@ function highlightCard(index) {
         card.classList.remove('card--highlight');
         highlightTimer = null;
     }, 1500);
+}
+
+function renderFilters(events) {
+    if (!filterBar) return;
+
+    const available = new Set();
+    events.forEach(event => (event.tags || []).forEach(tag => available.add(tag)));
+
+    const ordered = [...BASE_FILTERS];
+
+    const extras = Array.from(available).filter(tag => !BASE_FILTERS.includes(tag));
+    extras.sort();
+    ordered.push(...extras);
+
+    const unique = ordered.filter((tag, index) => ordered.indexOf(tag) === index);
+
+    const buttons = unique.map(tag => {
+        const label = labelForTag(tag);
+        const classes = ['chip'];
+        if (tag === currentFilter) classes.push('chip--active');
+        return `<button class="${classes.join(' ')}" data-filter="${tag}">${label}</button>`;
+    });
+
+    buttons.push('<button id="surprise" class="chip chip--accent">Inspire me</button>');
+    filterBar.innerHTML = buttons.join('');
+    setActive(currentFilter);
+}
+
+function heatColor(ratio, alpha = .2) {
+    const clamped = Math.max(0, Math.min(1, ratio));
+    const hue = 260 - clamped * 180; // from violet to orange
+    const saturation = 80;
+    const lightness = 65 - clamped * 15;
+    return `hsla(${Math.round(hue)}, ${saturation}%, ${Math.round(lightness)}%, ${alpha})`;
+}
+
+function renderDensityMap(events) {
+    if (!densityEl) return;
+
+    const counts = new Array(7).fill(0);
+    let datedEvents = 0;
+    events.forEach(event => {
+        if (typeof event.dayIndex === 'number') {
+            counts[event.dayIndex] += 1;
+            datedEvents += 1;
+        }
+    });
+
+    if (!datedEvents) {
+        densityEl.hidden = false;
+        densityEl.innerHTML = '<p style="opacity:.7">No schedule data yet for this week.</p>';
+        updatePulseColor(counts);
+        return;
+    }
+
+    const max = Math.max(1, ...counts);
+    const cards = WEEK.map(day => {
+        const count = counts[day.index];
+        const ratio = count / max;
+        const strength = ratio ? (0.3 + ratio * 0.7) : 0.1;
+        const color = heatColor(ratio, .28);
+        return `<div class="density__cell" style="--density-strength:${strength.toFixed(2)};--density-color:${color}">
+            <div class="density__day">${day.full}</div>
+            <div class="density__count">${count}</div>
+            <div class="density__bar"><span></span></div>
+        </div>`;
+    }).join('');
+
+    densityEl.hidden = false;
+    densityEl.innerHTML = `<div class="density__grid">${cards}</div>`;
+    updatePulseColor(counts);
+}
+
+function updatePulseColor(counts) {
+    const today = new Date();
+    const todayIndex = today.getDay();
+    const max = Math.max(1, ...counts);
+    const todayRatio = (counts[todayIndex] || 0) / max;
+    const lightPulse = heatColor(todayRatio, .14);
+    const darkPulse = heatColor(todayRatio, .32);
+    document.documentElement.style.setProperty('--pulse-color', lightPulse);
+    document.documentElement.style.setProperty('--pulse-color-dark', darkPulse);
+}
+
+function renderClusters(events) {
+    if (!clusterDeckEl) return;
+
+    const groups = new Map();
+    events.forEach(event => {
+        const key = event.vibe || 'performance';
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(event);
+    });
+
+    const cards = VIBE_PROFILES
+        .filter(profile => groups.has(profile.id))
+        .map(profile => {
+            const list = groups.get(profile.id).slice().sort((a, b) => {
+                const aTime = a.starts_at ? new Date(a.starts_at).getTime() : Infinity;
+                const bTime = b.starts_at ? new Date(b.starts_at).getTime() : Infinity;
+                return aTime - bTime;
+            });
+            const sample = list[0];
+            const count = list.length;
+            const suffix = count === 1 ? 'event' : 'events';
+            const sampleWhen = [sample?.when, sample?.where].filter(Boolean).join(' • ');
+            const sampleLine = sample ? `${sample.title}${sampleWhen ? ` — ${sampleWhen}` : ''}` : '';
+            return `<article class="cluster-card" data-vibe="${profile.id}">
+                <span class="cluster-card__title">${profile.label}</span>
+                <span class="cluster-card__count">${count} ${suffix}</span>
+                <span class="cluster-card__sample">${sampleLine}</span>
+            </article>`;
+        }).join('');
+
+    clusterDeckEl.innerHTML = cards;
+    clusterDeckEl.hidden = !cards.length;
 }
 
 async function loadEvents() {
@@ -102,32 +514,68 @@ async function loadEvents() {
 
     console.warn('Falling back to embedded sample data');
     return [
-        { title: "Quiz at Det Akademiske Kvarter", when: "Thu 20:00", where: "Kvarteret", tags: ["quiz"], url: "https://kvarteret.no/" },
-        { title: "Midnight Rave", when: "Fri 23:59", where: "USF Verftet", tags: ["rave"], url: "https://ra.co/" },
-        { title: "Paint n’ Sip", when: "Sat 18:00", where: "Kulturhuset", tags: ["girls", "date"], url: "https://ticketco.events/" },
-        { title: "Cinema: Sci-Fi Classics", when: "Tonight 21:15", where: "Bergen Kino", tags: ["cinema", "date"], url: "https://bergenkino.no/" }
+        {
+            title: 'Quiz at Det Akademiske Kvarter',
+            when: 'Thu 20:00',
+            where: 'Kvarteret',
+            tags: ['quiz'],
+            url: 'https://kvarteret.no/'
+        },
+        {
+            title: 'Midnight Rave',
+            when: 'Fri 23:59',
+            where: 'USF Verftet',
+            tags: ['rave'],
+            url: 'https://ra.co/'
+        },
+        {
+            title: 'Paint n’ Sip',
+            when: 'Sat 18:00',
+            where: 'Kulturhuset',
+            tags: ['girls', 'date'],
+            url: 'https://ticketco.events/'
+        },
+        {
+            title: 'Cinema: Sci-Fi Classics',
+            when: 'Tonight 21:15',
+            where: 'Bergen Kino',
+            tags: ['cinema', 'date'],
+            url: 'https://bergenkino.no/'
+        }
     ];
 }
 
-async function boot() {
-    window.__ALL = await loadEvents();
-    applyFilter('all');
-}
-boot();
-
-filterBar.addEventListener('click', (e) => {
-    const btn = e.target.closest('button[data-filter]');
-    if (!btn) return;
-    applyFilter(btn.dataset.filter);
-});
-
-$('#surprise')?.addEventListener('click', () => {
+function handleSurprise() {
     const list = currentList.length ? currentList : (window.__ALL || []);
     if (!list.length) return;
     const idx = Math.floor(Math.random() * list.length);
     const event = list[idx];
     showSpotlight(event);
     highlightCard(idx);
+}
+
+async function boot() {
+    const rawEvents = await loadEvents();
+    const enhanced = enrichEvents(rawEvents);
+    window.__ALL = enhanced;
+    renderFilters(enhanced);
+    renderClusters(enhanced);
+    renderDensityMap(enhanced);
+    applyFilter(currentFilter);
+}
+
+boot();
+
+filterBar?.addEventListener('click', (e) => {
+    const button = e.target.closest('button');
+    if (!button) return;
+    if (button.dataset.filter) {
+        applyFilter(button.dataset.filter);
+        return;
+    }
+    if (button.id === 'surprise') {
+        handleSurprise();
+    }
 });
 
 $('#year').textContent = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- streamline layout styling with sticky filter chips, cleaned dark mode rules, and new badge colors for jazz, bar, and culture tags
- expand smart tag inference and base filters while keeping deduping and vibe clustering consistent
- improve density map handling with graceful empty states and keep pulse colors in sync with the weekly counts

## Testing
- node --check js/app.js

------
https://chatgpt.com/codex/tasks/task_e_68e38b3fbddc83318afb4d47c84eff52