### PR TITLE
Integrate tagging and deduplication into scraper pipeline

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -11,7 +11,10 @@
       "date"
     ],
     "when": "Fri 20:00",
-    "where": "Bergen Kino"
+    "where": "Bergen Kino",
+    "sources": [
+      "Bergen Kino"
+    ]
   },
   {
     "source": "USF Verftet",
@@ -21,10 +24,14 @@
     "starts_at": "2024-05-18T19:30:00+02:00",
     "venue": "USF Verftet",
     "tags": [
-      "culture"
+      "culture",
+      "jazz"
     ],
     "when": "Sat 19:30",
-    "where": "USF Verftet"
+    "where": "USF Verftet",
+    "sources": [
+      "USF Verftet"
+    ]
   },
   {
     "source": "Bergen Kjøtt",
@@ -34,10 +41,14 @@
     "starts_at": "2024-05-18T21:00:00+02:00",
     "venue": "Bergen Kjøtt",
     "tags": [
-      "culture"
+      "culture",
+      "lecture"
     ],
     "when": "Sat 21:00",
-    "where": "Bergen Kjøtt"
+    "where": "Bergen Kjøtt",
+    "sources": [
+      "Bergen Kjøtt"
+    ]
   },
   {
     "source": "Bergen Kunsthall",
@@ -47,10 +58,14 @@
     "starts_at": "2024-05-19T21:00:00+02:00",
     "venue": "Landmark",
     "tags": [
-      "culture"
+      "culture",
+      "late-night"
     ],
     "when": "Sun 21:00",
-    "where": "Landmark"
+    "where": "Landmark",
+    "sources": [
+      "Bergen Kunsthall"
+    ]
   },
   {
     "source": "Resident Advisor",
@@ -60,10 +75,15 @@
     "starts_at": "2024-05-19T23:00:00+02:00",
     "venue": "Bergen",
     "tags": [
-      "rave"
+      "late-night",
+      "rave",
+      "techno"
     ],
     "when": "Sun 23:00",
-    "where": "Bergen"
+    "where": "Bergen",
+    "sources": [
+      "Resident Advisor"
+    ]
   },
   {
     "source": "Østre",
@@ -73,10 +93,14 @@
     "starts_at": "2024-05-20T22:00:00+02:00",
     "venue": "Østre",
     "tags": [
-      "culture"
+      "culture",
+      "late-night"
     ],
     "when": "Mon 22:00",
-    "where": "Østre"
+    "where": "Østre",
+    "sources": [
+      "Østre"
+    ]
   },
   {
     "source": "Kennel Vinylbar",
@@ -85,8 +109,12 @@
     "city": "Bergen",
     "venue": "Kennel Vinylbar",
     "tags": [
-      "bar"
+      "bar",
+      "festival"
     ],
-    "where": "Kennel Vinylbar"
+    "where": "Kennel Vinylbar",
+    "sources": [
+      "Kennel Vinylbar"
+    ]
   }
 ]

--- a/scraper/run.py
+++ b/scraper/run.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 import json
 import os
+import re
+from datetime import datetime
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Callable, Iterable, List, Tuple
 
@@ -91,15 +94,151 @@ def _sort(events: List[dict]) -> List[dict]:
     return sorted(events, key=sort_key)
 
 
+CATEGORY_PATTERNS = {
+    "techno": re.compile(
+        r"\b(dj|club|techno|rave|house|electro|afterparty|warehouse|disco)\b",
+        re.IGNORECASE,
+    ),
+    "jazz": re.compile(r"\bjazz\b", re.IGNORECASE),
+    "lecture": re.compile(
+        r"\b(lecture|talk|seminar|conference|panel|debate|foredrag|samtale)\b",
+        re.IGNORECASE,
+    ),
+    "festival": re.compile(r"\b(festival|weekender)\b", re.IGNORECASE),
+    "underground": re.compile(r"\b(underground|basement|secret|warehouse)\b", re.IGNORECASE),
+    "family": re.compile(r"\b(family|familie|kids|children|barn|ungdom)\b", re.IGNORECASE),
+    "culture": re.compile(
+        r"\b(art|kunsthall|museum|culture|utstilling|performance|kunst|lecture|talk|seminar|conference|panel|debate|foredrag|samtale)\b",
+        re.IGNORECASE,
+    ),
+}
+
+LATE_NIGHT_KEYWORDS = re.compile(
+    r"\b(late night|afterparty|after-hours|night session)\b", re.IGNORECASE
+)
+
+
+def _append_unique(values: List[str], new_value: str) -> None:
+    if new_value and new_value not in values:
+        values.append(new_value)
+
+
+def _normalize_tags(tags: Iterable[str]) -> List[str]:
+    cleaned = sorted({tag.strip() for tag in tags if tag and tag.strip()})
+    return cleaned
+
+
+def _infer_tags(event: dict) -> None:
+    tags = set(event.get("tags", []))
+    haystack = " ".join(
+        part.lower() for part in (event.get("title"), event.get("venue")) if part
+    )
+
+    for tag, pattern in CATEGORY_PATTERNS.items():
+        if pattern.search(haystack):
+            tags.add(tag)
+
+    if LATE_NIGHT_KEYWORDS.search(haystack):
+        tags.add("late-night")
+
+    starts_at = event.get("starts_at")
+    if starts_at:
+        try:
+            dt = datetime.fromisoformat(starts_at)
+        except ValueError:
+            dt = None
+        if dt and (dt.hour >= 22 or dt.hour < 5):
+            tags.add("late-night")
+
+    if tags:
+        event["tags"] = _normalize_tags(tags)
+    elif "tags" in event:
+        event.pop("tags", None)
+
+
+def _normalize_title(value: str) -> str:
+    lowered = value.lower()
+    without_punct = re.sub(r"[^\w\s]", " ", lowered)
+    collapsed = re.sub(r"\s+", " ", without_punct)
+    return collapsed.strip()
+
+
+def _titles_match(a: str, b: str, threshold: float = 0.8) -> bool:
+    if not a or not b:
+        return False
+    ratio = SequenceMatcher(None, _normalize_title(a), _normalize_title(b)).ratio()
+    return ratio >= threshold
+
+
+def _same_event_day(a: dict, b: dict) -> bool:
+    starts_a = a.get("starts_at")
+    starts_b = b.get("starts_at")
+    if not starts_a or not starts_b:
+        return False
+    return starts_a[:10] == starts_b[:10]
+
+
+def _merge_into(existing: dict, incoming: dict) -> None:
+    sources = existing.setdefault("sources", [])
+    _append_unique(sources, existing.get("source"))
+    _append_unique(sources, incoming.get("source"))
+
+    incoming_sources = incoming.get("sources", [])
+    for extra_source in incoming_sources:
+        _append_unique(sources, extra_source)
+
+    existing_tags = set(existing.get("tags", []))
+    incoming_tags = set(incoming.get("tags", []))
+    if incoming_tags or existing_tags:
+        existing["tags"] = _normalize_tags(existing_tags | incoming_tags)
+
+    for key in ("starts_at", "ends_at", "venue", "city", "when", "where"):
+        if not existing.get(key) and incoming.get(key):
+            existing[key] = incoming[key]
+
+
+def _merge_related(events: List[dict]) -> Tuple[List[dict], int]:
+    merged: List[dict] = []
+    merges = 0
+
+    for event in events:
+        _infer_tags(event)
+        matched = False
+        for candidate in merged:
+            if not _same_event_day(candidate, event):
+                continue
+            if not _titles_match(candidate.get("title", ""), event.get("title", "")):
+                continue
+            _merge_into(candidate, event)
+            merges += 1
+            matched = True
+            break
+
+        if not matched:
+            new_event = dict(event)
+            sources = []
+            _append_unique(sources, new_event.get("source"))
+            new_event["sources"] = sources
+            merged.append(new_event)
+
+    for event in merged:
+        if event.get("tags"):
+            event["tags"] = _normalize_tags(event["tags"])
+
+    return merged, merges
+
+
 def main():
     collected: List[dict] = []
     for name, fetch in _sources():
         collected.extend(_run_source(name, fetch))
 
     events = _sort(_dedupe(collected))
+    events, merges = _merge_related(events)
 
     OUT.parent.mkdir(parents=True, exist_ok=True)
     OUT.write_text(json.dumps(events, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"Merged related events: {merges}")
     print(f"Wrote {len(events)} events → {OUT}")
 
 


### PR DESCRIPTION
## Summary
- embed automatic tag inference and cross-source merge handling directly inside `scraper/run.py`
- normalize event titles before fuzzy matching so duplicates across sources are merged and their source lists updated
- remove the standalone `scraper/process_events.py` helper that is now redundant

## Testing
- python -m compileall scraper/run.py

------
https://chatgpt.com/codex/tasks/task_e_68e38cc5fdb883318d659d47a99d5b2f