### PR TITLE
Harden scraper pipeline and refresh SPONTIS UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Static site (GitHub Pages) · Vanilla JS/CSS · Data i `/data/events.sample.json
   - `ENABLE_IG_KENNEL` — Kennel Vinylbar (default av; forvent 403 mulig)
   - `SCRAPE_RA` må være aktivert for RA, de andre fungerer uavhengig.
 - Runneren deduper på (`title`, `starts_at`, `url`), logger antall per kilde og feiler ikke om én kilde skulle falle igjennom — du får alltid gyldig JSON (tom liste om det ikke finnes events).
+- Offline test? Kjør `python -m scraper.run --offline --no-update-views` for å skrive sample-data lokalt uten nettverkskall.

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,4 +1,5 @@
 :root {
+    color-scheme: dark;
     --coral: #FF4F4F;
     --navy: #0D1B2A;
     --off: #F8F6F2;
@@ -9,8 +10,22 @@
     --cluster-performance: linear-gradient(135deg, #05342f, #2EC4B6);
     --cluster-talks: linear-gradient(135deg, #4b0d1d, #FF4F87);
     --cluster-experimental: linear-gradient(135deg, #0b1a3c, #4B7BEC);
-    --pulse-color: rgba(255, 79, 79, .08);
-    --pulse-color-dark: rgba(64, 140, 255, .18);
+    --pulse-color: rgba(64, 140, 255, .18);
+    --pulse-color-dark: rgba(64, 140, 255, .28);
+    --bg-base: #0b1220;
+    --bg-surface: rgba(17, 26, 45, 0.82);
+    --text-primary: #e5e7eb;
+    --text-muted: #94a3b8;
+    --chip-bg: rgba(15, 23, 42, 0.72);
+    --chip-border: rgba(148, 163, 184, 0.35);
+    --chip-active-bg: var(--coral);
+    --chip-active-text: #0b1220;
+    --card-bg: rgba(15, 23, 42, 0.88);
+    --card-border: rgba(148, 163, 184, 0.28);
+    --link-surface: rgba(239, 68, 68, 0.12);
+    --link-text: #f8fafc;
+    --spotlight-bg: #1e293b;
+    --footer-muted: rgba(148, 163, 184, 0.8);
     padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
 }
@@ -24,10 +39,32 @@ body {
     margin: 0;
     min-height: 100%;
     background:
-        radial-gradient(circle at 15% 10%, var(--pulse-color, rgba(255, 79, 79, .08)), transparent 55%),
-        var(--off);
-    color: var(--ink);
+        radial-gradient(circle at 15% 10%, var(--pulse-color), transparent 55%),
+        var(--bg-base);
+    color: var(--text-primary);
     font: 16px/1.5 "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        color-scheme: light;
+        --pulse-color: rgba(255, 79, 79, .08);
+        --pulse-color-dark: rgba(64, 140, 255, .18);
+        --bg-base: #F8F6F2;
+        --bg-surface: rgba(255, 255, 255, 0.92);
+        --text-primary: #0F172A;
+        --text-muted: #475569;
+        --chip-bg: rgba(255, 255, 255, 0.85);
+        --chip-border: rgba(148, 163, 184, 0.28);
+        --chip-active-bg: var(--navy);
+        --chip-active-text: #f8fafc;
+        --card-bg: #ffffff;
+        --card-border: #e2e8f0;
+        --link-surface: rgba(13, 27, 42, 0.04);
+        --link-text: #0f172a;
+        --spotlight-bg: #FFEBD1;
+        --footer-muted: rgba(71, 85, 105, 0.8);
+    }
 }
 
 .container {
@@ -53,53 +90,99 @@ body {
 
 .brand .tagline {
     margin: .25rem 0 0;
-    color: var(--navy);
+    color: var(--text-muted);
     font-size: clamp(1rem, 2.3vw, 1.5rem);
+}
+
+.hero__lede {
+    margin: 1rem 0 0;
+    max-width: 720px;
+    color: var(--text-muted);
+    font-size: 1rem;
+}
+
+.hero__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+    margin-top: 1rem;
+    color: var(--text-muted);
+    font-size: .9rem;
+}
+
+.hero__meta span {
+    display: inline-flex;
+    align-items: center;
+    padding: .35rem .7rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, .14);
+    border: 1px solid var(--card-border);
 }
 
 .filters {
     position: sticky;
     top: calc(env(safe-area-inset-top) + 8px);
     z-index: 10;
-    display: flex;
-    flex-wrap: wrap;
-    gap: .5rem;
-    margin-top: 1rem;
-    align-items: center;
-    padding: .5rem;
-    background: rgba(255, 255, 255, .75);
-    border-radius: 16px;
-    box-shadow: 0 12px 32px rgba(13, 27, 42, .08);
-    backdrop-filter: blur(10px);
+    display: grid;
+    gap: .75rem;
+    margin-top: 1.25rem;
+    padding: .75rem;
+    background: var(--bg-surface);
+    border-radius: 18px;
+    box-shadow: 0 18px 32px rgba(8, 15, 26, .38);
+    backdrop-filter: blur(16px);
 }
 
 .filter-shell {
     position: relative;
 }
 
-.filters--legacy {
-    position: static;
-    top: auto;
-    background: transparent;
-    box-shadow: none;
-    backdrop-filter: none;
-    padding: 0;
-    margin-top: 1.5rem;
-    gap: .4rem;
+.filters__row {
+    display: flex;
+    gap: .5rem;
+    align-items: center;
+    flex-wrap: wrap;
 }
 
-.filters--legacy .chip {
-    background: rgba(255, 255, 255, .85);
+.filters__row--datasets {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: .15rem;
+    margin-bottom: -.15rem;
+    -webkit-overflow-scrolling: touch;
+}
+
+.filters__row--datasets .chip {
+    flex: 0 0 auto;
+}
+
+.filters__row::-webkit-scrollbar {
+    display: none;
+}
+
+.filters__row {
+    scrollbar-width: none;
 }
 
 .chip {
-    border: 1px solid #e6e6e6;
-    background: #fff;
+    border: 1px solid var(--chip-border);
+    background: var(--chip-bg);
     border-radius: 999px;
     padding: .6rem 1rem;
     cursor: pointer;
     min-height: 44px;
-    transition: transform .15s ease, box-shadow .15s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    color: var(--text-primary);
+    font-weight: 500;
+    transition: transform .15s ease, box-shadow .15s ease, background .15s ease;
+    white-space: nowrap;
+}
+
+.chip:focus-visible {
+    outline: 2px solid var(--coral);
+    outline-offset: 2px;
 }
 
 .chip:active,
@@ -107,19 +190,21 @@ body {
     transform: translateY(1px);
 }
 
-.filters [data-scope="dataset"] {
+.chip--dataset {
     font-weight: 600;
 }
 
 .chip--active {
-    border-color: var(--navy);
-    color: #fff;
-    background: var(--navy);
+    border-color: transparent;
+    color: var(--chip-active-text);
+    background: var(--chip-active-bg);
+    box-shadow: 0 8px 24px rgba(255, 79, 79, .35);
 }
 
 .chip--accent {
     background: var(--gold);
     border-color: transparent;
+    color: #1f2937;
 }
 
 .cluster-deck {
@@ -187,9 +272,10 @@ body {
 }
 
 .density__cell {
-    background: rgba(13, 27, 42, .07);
+    background: rgba(148, 163, 184, .12);
+    border: 1px solid var(--card-border);
     border-radius: 18px;
-    padding: .75rem 1rem;
+    padding: .85rem 1rem;
     display: grid;
     gap: .35rem;
     align-items: flex-start;
@@ -221,7 +307,7 @@ body {
 .density__bar {
     height: 6px;
     border-radius: 999px;
-    background: rgba(15, 23, 42, .1);
+    background: rgba(148, 163, 184, .25);
     overflow: hidden;
 }
 
@@ -235,16 +321,22 @@ body {
 .grid {
     display: grid;
     gap: 1rem;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     margin-top: 1rem;
+}
+
+.empty-state {
+    opacity: .7;
+    margin: 0;
+    color: var(--text-muted);
 }
 
 .heatmap {
     margin-top: 1.5rem;
     padding: 1rem 1.25rem;
     border-radius: 18px;
-    background: #fff;
-    border: 1px solid #eee;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
 }
 
 .heatmap__title {
@@ -253,7 +345,7 @@ body {
     font-weight: 600;
     letter-spacing: .02em;
     text-transform: uppercase;
-    color: #475569;
+    color: var(--text-muted);
 }
 
 .heatmap__grid {
@@ -274,7 +366,7 @@ body {
 .heatmap__bar {
     width: 100%;
     border-radius: 999px;
-    background: linear-gradient(180deg, rgba(13, 27, 42, .85), rgba(13, 27, 42, .55));
+    background: linear-gradient(180deg, rgba(248, 250, 252, .85), rgba(226, 232, 240, .45));
     min-height: 6px;
 }
 
@@ -286,12 +378,12 @@ body {
     font-size: .75rem;
     letter-spacing: .04em;
     text-transform: uppercase;
-    color: #64748b;
+    color: var(--text-muted);
 }
 
 .heatmap__count {
     font-size: .75rem;
-    color: #0f172a;
+    color: var(--text-primary);
 }
 
 .spotlight {
@@ -299,9 +391,9 @@ body {
     margin-bottom: .75rem;
     padding: 1rem 1.25rem;
     border-radius: 18px;
-    background: var(--gold);
-    color: var(--navy);
-    box-shadow: 0 12px 32px rgba(255, 200, 87, .25);
+    background: var(--spotlight-bg);
+    color: var(--text-primary);
+    box-shadow: 0 16px 36px rgba(8, 15, 26, .35);
     opacity: 0;
     transform: translateY(.25rem);
     transition: opacity .25s ease, transform .25s ease;
@@ -328,7 +420,15 @@ body {
 
 .spotlight__meta {
     font-size: .9rem;
-    opacity: .8;
+    color: var(--text-muted);
+    margin-bottom: .4rem;
+}
+
+.spotlight__sources {
+    font-size: .8rem;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--text-muted);
     margin-bottom: .6rem;
 }
 
@@ -339,6 +439,9 @@ body {
     font-weight: 600;
     color: inherit;
     text-decoration: none;
+    background: var(--link-surface);
+    padding: .5rem .85rem;
+    border-radius: 999px;
 }
 
 .spotlight__link::after {
@@ -348,14 +451,14 @@ body {
 }
 
 .card {
-    background: #fff;
-    border: 1px solid #eee;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
     border-radius: 18px;
-    padding: 1rem;
+    padding: 1.1rem;
     display: flex;
     flex-direction: column;
-    gap: .35rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, .04);
+    gap: .45rem;
+    box-shadow: 0 1px 3px rgba(8, 15, 26, .22);
 }
 
 .card--highlight {
@@ -370,6 +473,7 @@ body {
     border-radius: 999px;
     background: #f3f4f6;
     border: 1px solid #e5e7eb;
+    color: #0f172a;
 }
 
 .badge--date { background: #FFEBD1; border-color: #FFD69B; }
@@ -394,7 +498,17 @@ body {
 
 .card p {
     margin: 0;
-    color: #475569;
+    color: var(--text-muted);
+}
+
+.card__details {
+    font-size: .95rem;
+    color: var(--text-primary);
+}
+
+.card__summary {
+    font-size: .9rem;
+    color: var(--text-muted);
 }
 
 .meta {
@@ -405,28 +519,100 @@ body {
 }
 
 .card__sources {
-    font-size: .8rem;
+    font-size: .75rem;
     text-transform: uppercase;
     letter-spacing: .08em;
     margin-top: .35rem;
-    opacity: .75;
+    color: var(--text-muted);
 }
 
 .card a {
     margin-top: auto;
     text-decoration: none;
-    padding: .6rem .8rem;
+    padding: .65rem .85rem;
     border-radius: 12px;
-    background: var(--navy);
-    color: #fff;
+    background: var(--link-surface);
+    color: var(--link-text);
     text-align: center;
-    transition: transform .15s ease;
+    transition: transform .15s ease, box-shadow .15s ease;
+}
+
+.card a:hover {
+    box-shadow: 0 12px 24px rgba(239, 68, 68, .25);
 }
 
 .footer {
-    opacity: .7;
+    opacity: 1;
+    color: var(--footer-muted);
     font-size: .9rem;
     padding-bottom: calc(env(safe-area-inset-bottom) + 24px);
+}
+
+.about {
+    margin-top: 3rem;
+    margin-bottom: 3rem;
+    padding: 2rem;
+    border-radius: 24px;
+    background: var(--bg-surface);
+    border: 1px solid var(--card-border);
+    box-shadow: 0 18px 36px rgba(8, 15, 26, .28);
+}
+
+.about h2 {
+    margin-top: 0;
+    font-size: 1.6rem;
+}
+
+.about__text {
+    margin: 1rem 0;
+    color: var(--text-muted);
+    max-width: 720px;
+}
+
+.about__sources-title {
+    margin-top: 2rem;
+    margin-bottom: .5rem;
+    font-size: 1.2rem;
+}
+
+.about__hint {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    color: var(--text-muted);
+}
+
+.sources__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: .4rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.sources__list li {
+    padding: .5rem .75rem;
+    border-radius: 12px;
+    background: rgba(148, 163, 184, .14);
+    border: 1px solid var(--card-border);
+    color: var(--text-primary);
+    font-size: .9rem;
+}
+
+.about__cta {
+    margin-top: 1.5rem;
+}
+
+.about__cta a {
+    color: var(--link-text);
+    background: var(--link-surface);
+    padding: .45rem .75rem;
+    border-radius: 10px;
+    text-decoration: none;
+}
+
+.about__cta a:hover {
+    box-shadow: 0 12px 24px rgba(239, 68, 68, .2);
 }
 
 @keyframes cardPulse {
@@ -439,65 +625,3 @@ body {
     html { font-size: 17px; }
 }
 
-@media (prefers-color-scheme: dark) {
-    body {
-        background:
-            radial-gradient(circle at 15% 10%, var(--pulse-color-dark, rgba(64, 140, 255, .18)), transparent 55%),
-            #0b1220;
-        color: #e5e7eb;
-    }
-
-    .brand .tagline { color: #cbd5e1; }
-
-    .filters {
-        background: rgba(15, 23, 42, .72);
-        box-shadow: 0 12px 32px rgba(8, 15, 26, .4);
-    }
-
-    .chip {
-        background: #0f172a;
-        border-color: #1f2937;
-        color: #e5e7eb;
-    }
-
-    .card {
-        background: #0f172a;
-        border-color: #0b1220;
-    }
-
-    .card a {
-        background: #1f2a3a;
-        color: #f8fafc;
-    }
-
-    .badge {
-        color: #0f172a;
-    }
-
-    .spotlight {
-        background: #1e293b;
-        color: #f8fafc;
-        box-shadow: 0 18px 36px rgba(8, 15, 26, .45);
-    }
-
-    .heatmap {
-        background: #0f172a;
-        border-color: #1f2937;
-    }
-
-    .heatmap__title {
-        color: #cbd5e1;
-    }
-
-    .heatmap__bar {
-        background: linear-gradient(180deg, rgba(248, 250, 252, .85), rgba(226, 232, 240, .55));
-    }
-
-    .heatmap__day {
-        color: #94a3b8;
-    }
-
-    .heatmap__count {
-        color: #e2e8f0;
-    }
-}

--- a/index.html
+++ b/index.html
@@ -9,14 +9,25 @@
         content="Spontis: concerts, quiz nights, cinema, workshops and spontaneous fun — right now." />
     <meta property="og:title" content="SPONTIS" />
     <meta property="og:description" content="What’s on. Right now." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://spontis-app.github.io/" />
+    <meta property="og:site_name" content="SPONTIS" />
     <meta property="og:image" content="/assets/og-image.png" />
-    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./css/styles.css?v=1">
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="SPONTIS — What’s on. Right now." />
+    <meta name="twitter:description" content="Discover concerts, cinema, workshops and late-night fun in Bergen right now." />
+    <meta name="twitter:image" content="/assets/og-image.png" />
+    <meta name="application-name" content="SPONTIS" />
+    <meta name="apple-mobile-web-app-title" content="SPONTIS" />
+    <meta name="author" content="SPONTIS" />
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" sizes="any">
+    <link rel="apple-touch-icon" href="/assets/favicon.svg">
+    <link rel="canonical" href="https://spontis-app.github.io/">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="./css/styles.css?v=1">
     <meta name="theme-color" content="#F8F6F2" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0b1220" media="(prefers-color-scheme: dark)">
 </head>
@@ -27,10 +38,16 @@
             <h1 class="logo">SPONTIS</h1>
             <p class="tagline">What’s on. Right now.</p>
         </div>
+        <p class="hero__lede">Spontis keeps an eye on Bergen’s independent culture scene – concerts, cinema, club nights, workshops and more – refreshed automatically throughout the day.</p>
+        <div class="hero__meta" aria-label="System status">
+            <span>Timezone: Europe/Oslo</span>
+            <span>Validated listings with automatic clean-up</span>
+            <span>Dark mode by default</span>
+        </div>
     </header>
 
     <div class="container filter-shell">
-        <nav id="filter-chips" class="filters" aria-label="Sticky filter chips"></nav>
+        <nav id="filter-chips" class="filters" aria-label="Event filters"></nav>
     </div>
 
     <main class="container">
@@ -42,10 +59,19 @@
         </section>
         <div id="spotlight" class="spotlight" role="status" aria-live="polite" hidden></div>
         <section id="events" class="grid"></section>
+        <section class="about" id="about">
+            <h2>About SPONTIS</h2>
+            <p class="about__text">SPONTIS is a lightweight, zero-login guide to what’s happening in Bergen right now. We collect public schedules from trusted organisers, normalise timezones, validate the schema and remove past events automatically so the list stays fresh.</p>
+            <p class="about__text">Everything runs as open data on GitHub Pages. Filters are fast, mobile-friendly and tuned for dark mode. Tap any listing to jump to the original organiser for tickets or details.</p>
+            <h3 class="about__sources-title">Live sources</h3>
+            <p class="about__hint">We always credit where the information comes from – the list below updates whenever the scraper runs.</p>
+            <ul id="source-rollup" class="sources__list" aria-live="polite"></ul>
+            <p class="about__cta">Want to contribute a new source or fix a bug? <a href="https://github.com/spontis-app/spontis-app.github.io" target="_blank" rel="noopener noreferrer">Open a pull request on GitHub</a>.</p>
+        </section>
     </main>
 
     <footer class="container footer">
-        <p>© <span id="year"></span> Spontis. Bergen at your fingertips.</p>
+        <p>© <span id="year"></span> SPONTIS — built in Bergen and maintained with care.</p>
     </footer>
 
     <script src="/js/app.js" defer></script>

--- a/scraper/http.py
+++ b/scraper/http.py
@@ -1,0 +1,67 @@
+"""HTTP helpers with retry-aware sessions for the SPONTIS scraper."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any, Mapping, MutableMapping, Optional
+
+import requests
+from requests import Response
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+DEFAULT_TIMEOUT = float(os.getenv("SPONTIS_HTTP_TIMEOUT", "25"))
+
+
+def _default_headers() -> dict[str, str]:
+    headers: dict[str, str] = {
+        "User-Agent": os.getenv(
+            "SPONTIS_HTTP_USER_AGENT",
+            "SpontisBot/1.1 (+https://spontis-app.github.io)",
+        ),
+        "Accept-Language": os.getenv("SPONTIS_HTTP_LANG", "nb,en;q=0.8"),
+    }
+    return headers
+
+
+def _build_retry() -> Retry:
+    return Retry(
+        total=int(os.getenv("SPONTIS_HTTP_RETRIES", "3")),
+        connect=int(os.getenv("SPONTIS_HTTP_RETRIES", "3")),
+        read=int(os.getenv("SPONTIS_HTTP_RETRIES", "3")),
+        backoff_factor=float(os.getenv("SPONTIS_HTTP_BACKOFF", "0.6")),
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=("GET", "HEAD", "OPTIONS"),
+        raise_on_status=False,
+    )
+
+
+@lru_cache(maxsize=1)
+def get_session() -> requests.Session:
+    session = requests.Session()
+    retry = _build_retry()
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    session.headers.update(_default_headers())
+    return session
+
+
+def get(
+    url: str,
+    *,
+    timeout: Optional[float] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    **kwargs: Any,
+) -> Response:
+    session = get_session()
+    request_headers: MutableMapping[str, str]
+    if headers:
+        request_headers = session.headers.copy()
+        request_headers.update(headers)
+    else:
+        request_headers = session.headers
+    response = session.get(url, timeout=timeout or DEFAULT_TIMEOUT, headers=request_headers, **kwargs)
+    response.raise_for_status()
+    return response
+

--- a/scraper/sources/bergen_kjott.py
+++ b/scraper/sources/bergen_kjott.py
@@ -7,10 +7,10 @@ from typing import Optional, Tuple
 from urllib.parse import urljoin
 
 import dateparser
-import requests
 from bs4 import BeautifulSoup, Tag
 
 from scraper.normalize import build_event, to_weekday_label
+from scraper.http import get as http_get
 
 PROGRAM_URL = "https://www.bergenkjott.org/kalendar"
 HEADERS = {
@@ -52,7 +52,7 @@ def _extract_datetime(node: Tag) -> Optional[datetime]:
 
 def _fetch_page(url: str) -> Tuple[Optional[BeautifulSoup], Optional[int]]:
     try:
-        resp = requests.get(url, headers=HEADERS, timeout=TIMEOUT, allow_redirects=True)
+        resp = http_get(url, headers=HEADERS, timeout=TIMEOUT, allow_redirects=True)
     except Exception:
         return None, None
 

--- a/scraper/sources/bergen_kunsthall.py
+++ b/scraper/sources/bergen_kunsthall.py
@@ -7,10 +7,10 @@ from typing import Iterable, Optional, Tuple
 from urllib.parse import urljoin
 
 import dateparser
-import requests
 from bs4 import BeautifulSoup, Tag
 
 from scraper.normalize import build_event, to_weekday_label
+from scraper.http import get as http_get
 
 EVENT_URLS = [
     "https://www.kunsthall.no/en/events/",
@@ -55,8 +55,7 @@ def _extract_datetime(node: Tag) -> Optional[datetime]:
 
 def _fetch(url: str) -> Optional[BeautifulSoup]:
     try:
-        resp = requests.get(url, headers=HEADERS, timeout=TIMEOUT)
-        resp.raise_for_status()
+        resp = http_get(url, headers=HEADERS, timeout=TIMEOUT)
     except Exception:
         return None
     return BeautifulSoup(resp.text, "html.parser")

--- a/scraper/sources/kennel_vinylbar.py
+++ b/scraper/sources/kennel_vinylbar.py
@@ -7,9 +7,9 @@ from datetime import datetime
 from typing import List, Optional
 
 import dateparser
-import requests
 
 from scraper.normalize import build_event, to_weekday_label
+from scraper.http import get as http_get
 
 PROFILE_URL = "https://www.instagram.com/kennelvinylbar/"
 HEADERS = {
@@ -34,8 +34,7 @@ def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
 
 def _fetch_profile_html() -> Optional[str]:
     try:
-        resp = requests.get(PROFILE_URL, headers=HEADERS, timeout=TIMEOUT)
-        resp.raise_for_status()
+        resp = http_get(PROFILE_URL, headers=HEADERS, timeout=TIMEOUT)
     except Exception:
         return None
     return resp.text

--- a/scraper/sources/ostre.py
+++ b/scraper/sources/ostre.py
@@ -7,10 +7,10 @@ from typing import Optional, Tuple
 from urllib.parse import urljoin
 
 import dateparser
-import requests
 from bs4 import BeautifulSoup, Tag
 
 from scraper.normalize import TZ, build_event, to_weekday_label
+from scraper.http import get as http_get
 
 PROGRAM_URL = "https://www.ekko.no/ostre"
 HEADERS = {
@@ -62,8 +62,7 @@ def _extract_datetime(node: Tag) -> Optional[datetime]:
 
 
 def fetch() -> list[dict]:
-    response = requests.get(PROGRAM_URL, headers=HEADERS, timeout=25)
-    response.raise_for_status()
+    response = http_get(PROGRAM_URL, headers=HEADERS)
     soup = BeautifulSoup(response.text, "html.parser")
 
     events: list[dict] = []

--- a/scraper/sources/resident_advisor.py
+++ b/scraper/sources/resident_advisor.py
@@ -1,16 +1,17 @@
 from datetime import datetime
-import requests
-from bs4 import BeautifulSoup
+
 import dateparser
+from bs4 import BeautifulSoup
+
 from scraper.normalize import TZ, build_event, to_weekday_label
+from scraper.http import get as http_get
 
 HEADERS = {"User-Agent":"SpontisBot/0.1 (+https://spontis-app.github.io)","Accept-Language":"en,nb;q=0.7"}
 BASE = "https://ra.co"
 CITY_URL = f"{BASE}/events/no/bergen"
 
 def fetch() -> list[dict]:
-    r = requests.get(CITY_URL, headers=HEADERS, timeout=20)
-    r.raise_for_status()
+    r = http_get(CITY_URL, headers=HEADERS, timeout=20)
     soup = BeautifulSoup(r.text, "html.parser")
 
     items = []

--- a/scraper/sources/usf_verftet.py
+++ b/scraper/sources/usf_verftet.py
@@ -7,10 +7,10 @@ from typing import Optional, Tuple
 from urllib.parse import urljoin
 
 import dateparser
-import requests
 from bs4 import BeautifulSoup, Tag
 
 from scraper.normalize import build_event, to_weekday_label
+from scraper.http import get as http_get
 
 PROGRAM_URL = "https://usf.no/program/"
 HEADERS = {
@@ -52,8 +52,7 @@ def _extract_datetime(node: Tag) -> Optional[datetime]:
 
 def _fetch_detail(url: str) -> Optional[BeautifulSoup]:
     try:
-        resp = requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT)
-        resp.raise_for_status()
+        resp = http_get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT)
     except Exception:
         return None
     return BeautifulSoup(resp.text, "html.parser")
@@ -77,8 +76,7 @@ def _detail_datetime(url: str) -> Optional[datetime]:
 
 
 def fetch() -> list[dict]:
-    response = requests.get(PROGRAM_URL, headers=HEADERS, timeout=REQUEST_TIMEOUT)
-    response.raise_for_status()
+    response = http_get(PROGRAM_URL, headers=HEADERS, timeout=REQUEST_TIMEOUT)
     soup = BeautifulSoup(response.text, "html.parser")
 
     seen: set[Tuple[str, str]] = set()

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper modules for SPONTIS build scripts."""


### PR DESCRIPTION
## Summary
- add a shared HTTP helper with retries and refactor each scraper source to use it
- overhaul the scraper runner with logging, validation, timezone normalization, stale filtering, offline fallback, and optional view updates
- modernize the frontend with a dark-mode-first theme, responsive filters, spotlight/source attribution, and updated metadata/about copy

## Testing
- python -m scraper.run --help
- python -m scraper.run --offline --no-update-views --output /tmp/events.json

------
https://chatgpt.com/codex/tasks/task_e_68e3ba4901748331a4abff0de71494ff