### PR TITLE
Revive event cards with refreshed layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -325,6 +325,58 @@ body {
     margin-top: 1rem;
 }
 
+.events-shell {
+    margin-top: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.events-shell__header {
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+}
+
+.events-shell__titles {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+}
+
+.events-shell__eyebrow {
+    margin: 0;
+    font-size: .75rem;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.events-shell__title {
+    margin: 0;
+    font-size: clamp(1.65rem, 4vw, 2.4rem);
+}
+
+.events-shell__meta {
+    margin: 0;
+    max-width: 40ch;
+    color: var(--text-muted);
+    font-size: .95rem;
+    line-height: 1.5;
+}
+
+@media (min-width: 768px) {
+    .events-shell__header {
+        flex-direction: row;
+        align-items: flex-end;
+        justify-content: space-between;
+    }
+
+    .events-shell__meta {
+        text-align: right;
+    }
+}
+
 .empty-state {
     opacity: .7;
     margin: 0;
@@ -459,6 +511,28 @@ body {
     flex-direction: column;
     gap: .45rem;
     box-shadow: 0 1px 3px rgba(8, 15, 26, .22);
+    position: relative;
+    overflow: hidden;
+}
+
+.card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(140deg, rgba(255, 79, 79, .12), rgba(99, 102, 241, .12));
+    opacity: 0;
+    transition: opacity .25s ease;
+    pointer-events: none;
+}
+
+.card:hover::before,
+.card:focus-within::before {
+    opacity: 1;
+}
+
+.card > * {
+    position: relative;
+    z-index: 1;
 }
 
 .card--highlight {

--- a/css/theme.cool.css
+++ b/css/theme.cool.css
@@ -79,6 +79,15 @@
         --spotlight-bg: rgba(15, 23, 42, 0.08);
         --footer-border: rgba(148, 163, 184, 0.28);
     }
+
+    .card {
+        background: linear-gradient(165deg, rgba(255, 255, 255, 0.98), rgba(226, 232, 240, 0.65));
+    }
+
+    .card::before {
+        background: radial-gradient(circle at 14% 12%, rgba(14, 165, 233, 0.25), transparent 60%),
+            radial-gradient(circle at 82% 18%, rgba(236, 72, 153, 0.24), transparent 55%);
+    }
 }
 
 body {
@@ -283,10 +292,40 @@ body {
     font-size: 0.9rem;
 }
 
+.events-shell {
+    margin-top: clamp(2.4rem, 5vw, 3rem);
+    gap: clamp(1.25rem, 3vw, 1.8rem);
+}
+
+.events-shell__header {
+    padding: 0 clamp(0rem, 1vw, 0.5rem);
+}
+
+.events-shell__eyebrow {
+    color: var(--card-muted);
+    letter-spacing: 0.12em;
+}
+
+.events-shell__title {
+    font-size: clamp(1.9rem, 4vw, 2.6rem);
+    letter-spacing: 0.03em;
+}
+
+.events-shell__meta {
+    color: var(--page-muted);
+    max-width: 42ch;
+}
+
+@media (min-width: 768px) {
+    .events-shell__meta {
+        text-align: right;
+    }
+}
+
 .grid {
     display: grid;
-    gap: 1.35rem;
-    margin-top: 2rem;
+    gap: clamp(1.1rem, 3vw, 1.75rem);
+    margin-top: clamp(1.25rem, 3vw, 2.25rem);
 }
 
 @media (min-width: 640px) {
@@ -295,7 +334,7 @@ body {
     }
 }
 
-@media (min-width: 980px) {
+@media (min-width: 1024px) {
     .grid {
         grid-template-columns: repeat(3, minmax(0, 1fr));
     }
@@ -303,11 +342,11 @@ body {
 
 .card {
     display: grid;
-    gap: 0.75rem;
-    padding: 1.35rem;
+    gap: 0.85rem;
+    padding: clamp(1.2rem, 3vw, 1.55rem);
     border-radius: var(--page-radius-lg);
     border: 1px solid var(--card-border);
-    background: var(--card-bg);
+    background: linear-gradient(160deg, rgba(99, 102, 241, 0.18), rgba(15, 23, 42, 0.92));
     box-shadow: var(--card-shadow);
     transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
     position: relative;
@@ -317,21 +356,26 @@ body {
 .card::before {
     content: '';
     position: absolute;
-    inset: 0;
-    background: linear-gradient(160deg, rgba(148, 163, 184, 0.08), rgba(99, 102, 241, 0.1));
+    inset: -1px;
+    background: radial-gradient(circle at 12% 10%, rgba(236, 72, 153, 0.35), transparent 55%),
+        radial-gradient(circle at 88% 20%, rgba(59, 130, 246, 0.28), transparent 55%);
     opacity: 0;
-    transition: opacity 180ms ease;
+    transition: opacity 220ms ease, transform 220ms ease;
     pointer-events: none;
+    transform: scale(1.02);
 }
 
-.card:hover {
-    transform: translateY(-4px);
+.card:hover,
+.card:focus-within {
+    transform: translateY(-6px);
     box-shadow: var(--page-shadow-lift);
-    border-color: rgba(99, 102, 241, 0.45);
+    border-color: rgba(99, 102, 241, 0.55);
 }
 
-.card:hover::before {
+.card:hover::before,
+.card:focus-within::before {
     opacity: 1;
+    transform: scale(1);
 }
 
 .card h3 {

--- a/index.html
+++ b/index.html
@@ -60,7 +60,16 @@
             <div id="heatmap-bars" class="heatmap__grid" role="list"></div>
         </section>
         <div id="spotlight" class="spotlight" role="status" aria-live="polite" hidden></div>
-        <section id="events" class="grid"></section>
+        <section class="events-shell" aria-label="Browse events">
+            <header class="events-shell__header">
+                <div class="events-shell__titles">
+                    <p class="events-shell__eyebrow">Browse</p>
+                    <h2 class="events-shell__title">This week</h2>
+                </div>
+                <p class="events-shell__meta">Fresh drops from Bergen’s independent venues, updated throughout the day.</p>
+            </header>
+            <section id="events" class="grid" role="list"></section>
+        </section>
         <section class="about" id="about">
             <h2>About SPONTIS</h2>
             <p class="about__text">SPONTIS is a lightweight, zero-login guide to what’s happening in Bergen right now. We collect public schedules from trusted organisers, normalise timezones, validate the schema and remove past events automatically so the list stays fresh.</p>


### PR DESCRIPTION
## Summary
- add a dedicated "Browse" header wrapper around the event grid so the activity cards have on-page context
- refresh the base card styling with gradient overlays and hover/focus treatments to make listings feel present again
- tune the theme spacing and light/dark gradients for the grid so cards read clearly across breakpoints

## Testing
- Manual verification in browser (Chromium)


------
https://chatgpt.com/codex/tasks/task_e_68e3c3cdec1c83318acd83283fc24e85